### PR TITLE
Convert GitHub blockquote callouts to Quarto callouts

### DIFF
--- a/_scripts/mini_nvim.lua
+++ b/_scripts/mini_nvim.lua
@@ -407,6 +407,3 @@ end
 
 local _, err_msg_changelog = pcall(adjust_changelog)
 if err_msg_changelog then io.write('Error during adjusting changelog:\n' .. err_msg_changelog) end
-
--- Finish
-vim.cmd('quit')

--- a/_scripts/mini_nvim.sh
+++ b/_scripts/mini_nvim.sh
@@ -13,4 +13,4 @@ then
   cp -r _deps/mini.nvim/doc mini.nvim/doc
 fi
 
-nvim --headless --noplugin -u ./_scripts/mini_nvim.lua
+nvim --noplugin -l ./_scripts/mini_nvim.lua

--- a/mini.nvim/index.md
+++ b/mini.nvim/index.md
@@ -16,8 +16,9 @@ If you want to help this project grow but don't know where to start, check out [
 
 For a history of changes, including current development version, see [change log](CHANGELOG.md).
 
-> [!NOTE]
-> This was previously hosted at `echasnovski/mini.nvim`. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at `echasnovski/mini.nvim`. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ## Table of contents
 

--- a/mini.nvim/readmes/mini-ai.md
+++ b/mini.nvim/readmes/mini-ai.md
@@ -16,8 +16,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-ai.qmd
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-ai.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-align.md
+++ b/mini.nvim/readmes/mini-align.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-align.
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-align.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-animate.md
+++ b/mini.nvim/readmes/mini-animate.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-animat
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-animate.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-base16.md
+++ b/mini.nvim/readmes/mini-base16.md
@@ -16,8 +16,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-base16
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-base16.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-basics.md
+++ b/mini.nvim/readmes/mini-basics.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-basics
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-basics.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-bracketed.md
+++ b/mini.nvim/readmes/mini-bracketed.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-bracke
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-bracketed.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-bufremove.md
+++ b/mini.nvim/readmes/mini-bufremove.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-bufrem
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-bufremove.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-clue.md
+++ b/mini.nvim/readmes/mini-clue.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-clue.q
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-clue.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-colors.md
+++ b/mini.nvim/readmes/mini-colors.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-colors
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-colors.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-comment.md
+++ b/mini.nvim/readmes/mini-comment.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-commen
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-comment.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-completion.md
+++ b/mini.nvim/readmes/mini-completion.md
@@ -15,8 +15,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-comple
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-completion.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-cursorword.md
+++ b/mini.nvim/readmes/mini-cursorword.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-cursor
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-cursorword.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-deps.md
+++ b/mini.nvim/readmes/mini-deps.md
@@ -14,8 +14,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-deps.q
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-deps.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-diff.md
+++ b/mini.nvim/readmes/mini-diff.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-diff.q
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-diff.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-doc.md
+++ b/mini.nvim/readmes/mini-doc.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-doc.qm
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-doc.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-extra.md
+++ b/mini.nvim/readmes/mini-extra.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-extra.
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-extra.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-files.md
+++ b/mini.nvim/readmes/mini-files.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-files.
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-files.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-fuzzy.md
+++ b/mini.nvim/readmes/mini-fuzzy.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-fuzzy.
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-fuzzy.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-git.md
+++ b/mini.nvim/readmes/mini-git.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-git.qm
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-git.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-hipatterns.md
+++ b/mini.nvim/readmes/mini-hipatterns.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-hipatt
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-hipatterns.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-hues.md
+++ b/mini.nvim/readmes/mini-hues.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-hues.q
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-hues.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-icons.md
+++ b/mini.nvim/readmes/mini-icons.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-icons.
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-icons.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-indentscope.md
+++ b/mini.nvim/readmes/mini-indentscope.md
@@ -15,8 +15,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-indent
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-indentscope.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-jump.md
+++ b/mini.nvim/readmes/mini-jump.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-jump.q
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-jump.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-jump2d.md
+++ b/mini.nvim/readmes/mini-jump2d.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-jump2d
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-jump2d.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-keymap.md
+++ b/mini.nvim/readmes/mini-keymap.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-keymap
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-keymap.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-map.md
+++ b/mini.nvim/readmes/mini-map.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-map.qm
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-map.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-misc.md
+++ b/mini.nvim/readmes/mini-misc.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-misc.q
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-misc.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-move.md
+++ b/mini.nvim/readmes/mini-move.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-move.q
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-move.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-notify.md
+++ b/mini.nvim/readmes/mini-notify.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-notify
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-notify.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-operators.md
+++ b/mini.nvim/readmes/mini-operators.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-operat
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-operators.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-pairs.md
+++ b/mini.nvim/readmes/mini-pairs.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-pairs.
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-pairs.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-pick.md
+++ b/mini.nvim/readmes/mini-pick.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-pick.q
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-pick.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-sessions.md
+++ b/mini.nvim/readmes/mini-sessions.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-sessio
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-sessions.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-snippets.md
+++ b/mini.nvim/readmes/mini-snippets.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-snippe
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-snippets.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-splitjoin.md
+++ b/mini.nvim/readmes/mini-splitjoin.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-splitj
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-splitjoin.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-starter.md
+++ b/mini.nvim/readmes/mini-starter.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-starte
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-starter.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-statusline.md
+++ b/mini.nvim/readmes/mini-statusline.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-status
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-statusline.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-surround.md
+++ b/mini.nvim/readmes/mini-surround.md
@@ -17,8 +17,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-surrou
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-surround.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-tabline.md
+++ b/mini.nvim/readmes/mini-tabline.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-tablin
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-tabline.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-test.md
+++ b/mini.nvim/readmes/mini-test.md
@@ -15,8 +15,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-test.q
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-test.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-trailspace.md
+++ b/mini.nvim/readmes/mini-trailspace.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-trails
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-trailspace.md) if you want to mention this module.
 

--- a/mini.nvim/readmes/mini-visits.md
+++ b/mini.nvim/readmes/mini-visits.md
@@ -12,8 +12,9 @@ See more details in [Features](#features) and [Documentation](../doc/mini-visits
 
 ---
 
-> [!NOTE]
-> This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+::: {.callout-note}
+This was previously hosted at a personal `echasnovski` GitHub account. It was transferred to a dedicated organization to improve long term project stability. See more details [here](https://github.com/nvim-mini/mini.nvim/discussions/1970).
+:::
 
 ⦿ This is a part of [mini.nvim](https://github.com/nvim-mini/mini.nvim) library. Please use [this link](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-visits.md) if you want to mention this module.
 


### PR DESCRIPTION
Transforms blockquotes like `> [!NOTE]` into Quarto callouts using the `::: {.callout-<type>}` syntax.

Result:
<img width="1308" height="911" alt="Screenshot 2025-10-04 at 14-14-10 mini nvim – MINI" src="https://github.com/user-attachments/assets/6f1a762d-1333-4a64-bfb7-7ff271323c6e" />

Fixes #1

Also includes a minor script update :)